### PR TITLE
Tidy dex infra and only expose ingresses internally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update MC talos version v1.4.7 > v1.5.5.
 - Switch `/addons` dir to bases pattern to easier differentiate between cluster types.
 - Switch `/workloads/controllers` dir to bases pattern to easier differentiate between cluster types.
+- Tidy dex infra and only expose ingresses internally.
 
 ### Removed
 

--- a/apps/base/dex/dex-helmrelease.yaml
+++ b/apps/base/dex/dex-helmrelease.yaml
@@ -17,3 +17,4 @@ spec:
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
         kubernetes.io/tls-acme: "true"
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/apps/base/dex/dex-k8s-authenticator-helmrelease.yaml
+++ b/apps/base/dex/dex-k8s-authenticator-helmrelease.yaml
@@ -21,5 +21,5 @@ spec:
       className: nginx
       annotations:
         cert-manager.io/cluster-issuer: letsencrypt
-        external-dns.alpha.kubernetes.io/target: ingress.lab.a7d.dev
         kubernetes.io/tls-acme: "true"
+        nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/apps/base/oauth2-proxy/kustomization.yaml
+++ b/apps/base/oauth2-proxy/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: oauth2-proxy
 resources:
-  - helmrelease-a7d-dev.yaml
-  - helmrelease-analbeard-com.yaml
-  - helmrepository.yaml
-  - ingress-a7d-dev.yaml
-  - ingress-analbeard-com.yaml
-  - secrets.yaml
+- helmrelease-a7d-dev.yaml
+- helmrelease-analbeard-com.yaml
+- helmrepository.yaml
+- ingress-a7d-dev.yaml
+- ingress-analbeard-com.yaml
+- secrets.yaml

--- a/apps/room101-a7d-mc/dex/dex-k8s-authenticator-values.yaml
+++ b/apps/room101-a7d-mc/dex/dex-k8s-authenticator-values.yaml
@@ -18,17 +18,23 @@ spec:
           client_id: ${STATIC_CLIENT_ID}
           client_secret: ${STATIC_CLIENT_SECRET}
           redirect_uri: https://login.room101-a7d-mc.lab.a7d.dev/callback
-          k8s_master_uri: https://ha-lb-vip-k8s-mgmt.service.room101.a7d # CHANGEME
+          k8s_master_uri: https://k8s.room101-a7d-mc.lab.a7d.dev:6443
           k8s_ca_pem: |
             -----BEGIN CERTIFICATE-----
-            # CHANGEME
+            MIIBijCCATCgAwIBAgIRAO9Jkn0Es/kUI4DncQJgvOQwCgYIKoZIzj0EAwIwFTET
+            MBEGA1UEChMKa3ViZXJuZXRlczAeFw0yMzExMTcyMDQ3NDlaFw0zMzExMTQyMDQ3
+            NDlaMBUxEzARBgNVBAoTCmt1YmVybmV0ZXMwWTATBgcqhkjOPQIBBggqhkjOPQMB
+            BwNCAAS2QdLye3emGy9ERNSQr7wFbzhbZRNGRT8tesT9B2xypniGGpQfBujhbeWS
+            1UtpuJVm6nmD112mcFv9sSJ/ipdqo2EwXzAOBgNVHQ8BAf8EBAMCAoQwHQYDVR0l
+            BBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0O
+            BBYEFM5CnAgyrP8WxNukwVZQqeNxcbQHMAoGCCqGSM49BAMCA0gAMEUCIBj4VhPM
+            o6n5uFPV4N9+Og+WKmO6oX1fZwhjUdsmlhMwAiEAi3w9MSo3TS5zBCDFQgwB/Mrx
+            JdS2Ds2rhvKyX/oM/Dg=
             -----END CERTIFICATE-----
     envFrom:
       - secretRef:
           name: dex-k8s-authenticator-credentials
     ingress:
-      annotations:
-        external-dns.alpha.kubernetes.io/hostname: login.room101-a7d-mc.lab.a7d.dev
       hosts:
         - host: login.room101-a7d-mc.lab.a7d.dev
           paths:

--- a/apps/room101-a7d-mc/dex/dex-values.yaml
+++ b/apps/room101-a7d-mc/dex/dex-values.yaml
@@ -25,9 +25,6 @@ spec:
             key: clientSecret
     ingress:
       enabled: true
-      annotations:
-        external-dns.alpha.kubernetes.io/hostname: dex.room101-a7d-mc.lab.a7d.dev
-        external-dns.alpha.kubernetes.io/target: ingress.lab.a7d.dev
       hosts:
         - host: dex.room101-a7d-mc.lab.a7d.dev
           paths:

--- a/apps/room101-a7d-mc/dex/kustomization.yaml
+++ b/apps/room101-a7d-mc/dex/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base/dex
-namespace: "dex"
-namePrefix: "app-"
-patchesStrategicMerge:
-- dex-k8s-authenticator-values.yaml
-- dex-secret-dex-config.yaml
-- dex-secret-dex-github-secret.yaml
-- dex-secret-dex-k8s-authenticator-credentials.yaml
-- dex-values.yaml
+namespace: dex
+namePrefix: app-
+patches:
+- path: dex-k8s-authenticator-values.yaml
+- path: dex-secret-dex-config.yaml
+- path: dex-secret-dex-github-secret.yaml
+- path: dex-secret-dex-k8s-authenticator-credentials.yaml
+- path: dex-values.yaml

--- a/apps/room101-a7d-mc/kustomization.yaml
+++ b/apps/room101-a7d-mc/kustomization.yaml
@@ -2,5 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - dex
-- external-dns
 - oauth2-proxy

--- a/apps/room101-a7d-mc/oauth2-proxy/ingress-oauth2-proxy-a7d-dev.yaml
+++ b/apps/room101-a7d-mc/oauth2-proxy/ingress-oauth2-proxy-a7d-dev.yaml
@@ -3,9 +3,6 @@ kind: Ingress
 metadata:
   name: oauth2-proxy-a7d-dev
   namespace: oauth2-proxy
-  annotations:
-    external-dns.alpha.kubernetes.io/hostname: "oauth2-proxy.room101-a7d-mc.lab.a7d.dev"
-    external-dns.alpha.kubernetes.io/target: "ingress.lab.a7d.dev"
 spec:
   rules:
   - host: oauth2-proxy.room101-a7d-mc.lab.a7d.dev

--- a/apps/room101-a7d-mc/oauth2-proxy/ingress-oauth2-proxy-analbeard-com.yaml
+++ b/apps/room101-a7d-mc/oauth2-proxy/ingress-oauth2-proxy-analbeard-com.yaml
@@ -3,9 +3,6 @@ kind: Ingress
 metadata:
   name: oauth2-proxy-analbeard-com
   namespace: oauth2-proxy
-  annotations:
-    external-dns.alpha.kubernetes.io/hostname: "oauth2-proxy.room101-a7d-mc.lab.analbeard.com"
-    external-dns.alpha.kubernetes.io/target: "ingress.lab.a7d.dev"
 spec:
   rules:
   - host: oauth2-proxy.room101-a7d-mc.lab.analbeard.com

--- a/apps/room101-a7d-mc/oauth2-proxy/kustomization.yaml
+++ b/apps/room101-a7d-mc/oauth2-proxy/kustomization.yaml
@@ -2,11 +2,11 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base/oauth2-proxy
-namePrefix: "app-"
+namePrefix: app-
 patches:
 - path: ingress-oauth2-proxy-a7d-dev.yaml
   target:
-    kind: Ingress 
+    kind: Ingress
 - path: ingress-oauth2-proxy-analbeard-com.yaml
   target:
     kind: Ingress


### PR DESCRIPTION
- tidy and rework dex app config
- remove external-dns from kustomization
- tidy up oauth2-proxy deployments
- update changelog
