### PR TITLE
Explicitly set Qemu machine type to avoid Proxmox iPXE UUID bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable ssl-passthrough for `ingress-nginx`.
 - Align machine names across all resources.
 - Use variables across Qemu/Server/ServerClass resources.
+- Explicitly set Qemu machine type to avoid Proxmox iPXE UUID bug.
+
 ### Fixed
 
 - Attempt to finally correct machine names and ordering.

--- a/kubernetes/clusters/room101-a7d-mc/machines/qemu-master-203e63cb.yaml
+++ b/kubernetes/clusters/room101-a7d-mc/machines/qemu-master-203e63cb.yaml
@@ -37,6 +37,7 @@ spec:
   options:
     ostype: "l26"
     bios: "seabios"
+    machine: "pc-i440fx-8.0"
     smbios1: "uuid=${MASTER1_UUID},sku=${QEMU_MASTER_SKU_B64},family=${QEMU_FAMILY_B64},base64=1"
     scsihw: "virtio-scsi-pci"
     boot: "order=virtio0;net0"

--- a/kubernetes/clusters/room101-a7d-mc/machines/qemu-master-2d1e5620.yaml
+++ b/kubernetes/clusters/room101-a7d-mc/machines/qemu-master-2d1e5620.yaml
@@ -37,6 +37,7 @@ spec:
   options:
     ostype: "l26"
     bios: "seabios"
+    machine: "pc-i440fx-8.0"
     smbios1: "uuid=${MASTER2_UUID},sku=${QEMU_MASTER_SKU_B64},family=${QEMU_FAMILY_B64},base64=1"
     scsihw: "virtio-scsi-pci"
     boot: "order=virtio0;net0"

--- a/kubernetes/clusters/room101-a7d-mc/machines/qemu-master-7eb6cf89.yaml
+++ b/kubernetes/clusters/room101-a7d-mc/machines/qemu-master-7eb6cf89.yaml
@@ -37,6 +37,7 @@ spec:
   options:
     ostype: "l26"
     bios: "seabios"
+    machine: "pc-i440fx-8.0"
     smbios1: "uuid=${MASTER3_UUID},sku=${QEMU_MASTER_SKU_B64},family=${QEMU_FAMILY_B64},base64=1"
     scsihw: "virtio-scsi-pci"
     boot: "order=virtio0;net0"

--- a/kubernetes/clusters/room101-a7d-mc/machines/qemu-worker-461b9ad1.yaml
+++ b/kubernetes/clusters/room101-a7d-mc/machines/qemu-worker-461b9ad1.yaml
@@ -37,6 +37,7 @@ spec:
   options:
     ostype: "l26"
     bios: "seabios"
+    machine: "pc-i440fx-8.0"
     smbios1: "uuid=${WORKER1_UUID},sku=${QEMU_WORKER_SKU_B64},family=${QEMU_FAMILY_B64},base64=1"
     scsihw: "virtio-scsi-pci"
     boot: "order=virtio0;net0"

--- a/kubernetes/clusters/room101-a7d-mc/machines/qemu-worker-498eeb6c.yaml
+++ b/kubernetes/clusters/room101-a7d-mc/machines/qemu-worker-498eeb6c.yaml
@@ -37,6 +37,7 @@ spec:
   options:
     ostype: "l26"
     bios: "seabios"
+    machine: "pc-i440fx-8.0"
     smbios1: "uuid=${WORKER2_UUID},sku=${QEMU_WORKER_SKU_B64},family=${QEMU_FAMILY_B64},base64=1"
     scsihw: "virtio-scsi-pci"
     boot: "order=virtio0;net0"

--- a/kubernetes/clusters/room101-a7d-mc/machines/qemu-worker-6904e125.yaml
+++ b/kubernetes/clusters/room101-a7d-mc/machines/qemu-worker-6904e125.yaml
@@ -37,6 +37,7 @@ spec:
   options:
     ostype: "l26"
     bios: "seabios"
+    machine: "pc-i440fx-8.0"
     smbios1: "uuid=${WORKER3_UUID},sku=${QEMU_WORKER_SKU_B64},family=${QEMU_FAMILY_B64},base64=1"
     scsihw: "virtio-scsi-pci"
     boot: "order=virtio0;net0"

--- a/kubernetes/clusters/room101-a7d-mc/machines/qemu-worker-fc25565c.yaml
+++ b/kubernetes/clusters/room101-a7d-mc/machines/qemu-worker-fc25565c.yaml
@@ -37,6 +37,7 @@ spec:
   options:
     ostype: "l26"
     bios: "seabios"
+    machine: "pc-i440fx-8.0"
     smbios1: "uuid=${WORKER4_UUID},sku=${QEMU_WORKER_SKU_B64},family=${QEMU_FAMILY_B64},base64=1"
     scsihw: "virtio-scsi-pci"
     boot: "order=virtio0;net0"


### PR DESCRIPTION
ref https://github.com/siderolabs/sidero/issues/1321
