### PR TITLE
expose/scheduler controller manager metrics

### DIFF
--- a/flux/clusters/room101-a7d-mc/cluster-prereqs/cluster-vars-configmap.yaml
+++ b/flux/clusters/room101-a7d-mc/cluster-prereqs/cluster-vars-configmap.yaml
@@ -13,6 +13,7 @@ data:
   # infra versions
   # renovate: kubernetes/kubernetes
   K8S_VERSION: v1.32.3
+  # renovate: siderolabs/talos
   TALOS_VERSION: v1.9.4
 
   # salts to enable manual node rolling

--- a/flux/kubernetes/clusters/room101-a7d-mc/kustomization.yaml
+++ b/flux/kubernetes/clusters/room101-a7d-mc/kustomization.yaml
@@ -42,6 +42,11 @@ patches:
       group: controlplane.cluster.x-k8s.io
       kind: TalosControlPlane
       labelSelector: "flux-target=taloscontrolplane"
+  - path: ../../patches/shared-patches/controlplane/cluster-controllermanager-extraargs.yaml
+    target:
+      group: controlplane.cluster.x-k8s.io
+      kind: TalosControlPlane
+      labelSelector: "flux-target=taloscontrolplane"
   - path: ../../patches/shared-patches/controlplane/cluster-controlplane-endpoint.yaml
     target:
       group: controlplane.cluster.x-k8s.io
@@ -53,6 +58,11 @@ patches:
       kind: TalosControlPlane
       labelSelector: "flux-target=taloscontrolplane"
   - path: ../../patches/shared-patches/controlplane/cluster-proxy-disabled.yaml
+    target:
+      group: controlplane.cluster.x-k8s.io
+      kind: TalosControlPlane
+      labelSelector: "flux-target=taloscontrolplane"
+  - path: ../../patches/shared-patches/controlplane/cluster-scheduler-extraargs.yaml
     target:
       group: controlplane.cluster.x-k8s.io
       kind: TalosControlPlane

--- a/flux/kubernetes/patches/shared-patches/controlplane/cluster-controllermanager-extraargs.yaml
+++ b/flux/kubernetes/patches/shared-patches/controlplane/cluster-controllermanager-extraargs.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/controlPlaneConfig/controlplane/configPatches/0
+  value:
+    op: add
+    path: /cluster/controllerManager/extraArgs
+    value:
+      bind-address: 0.0.0.0

--- a/flux/kubernetes/patches/shared-patches/controlplane/cluster-scheduler-extraargs.yaml
+++ b/flux/kubernetes/patches/shared-patches/controlplane/cluster-scheduler-extraargs.yaml
@@ -1,0 +1,7 @@
+- op: add
+  path: /spec/controlPlaneConfig/controlplane/configPatches/0
+  value:
+    op: add
+    path: /cluster/scheduler/extraArgs
+    value:
+      bind-address: 0.0.0.0


### PR DESCRIPTION
- **add renovate comment for Talos versions**
- **Talos: expose controller-manager and scheduler ports for Prometheus**
