### PR TITLE
migrate external-dns chart away from bitnami

### DIFF
--- a/flux/clusters/room101-a7d-mc/30-addons.yaml
+++ b/flux/clusters/room101-a7d-mc/30-addons.yaml
@@ -59,23 +59,12 @@ spec:
         - op: add
           path: /spec/values/txtOwnerId
           value: "room101a7dmc"
-        - op: add
-          path: /spec/values/sources
-          value:
-            - crd
-            - ingress
-        - op: add
-          path: /spec/values/crd
-          value:
-            create: true
-            apiversion: "externaldns.k8s.io/v1alpha1" # CHECKME
-            kind: "DNSEndpoint"
         - op: replace
           path: /spec/chart/spec/version
-          # renovate: datasource=docker
+          # renovate: datasource=helm
           # chartname=external-dns
-          # url=oci://registry-1.docker.io/bitnamicharts
-          value: 8.9.2
+          # url=https://kubernetes-sigs.github.io/external-dns/
+          value: 1.18.0
       target:
         kind: HelmRelease
         name: external-dns

--- a/flux/clusters/room101-a7d-prod1/40-addons.yaml
+++ b/flux/clusters/room101-a7d-prod1/40-addons.yaml
@@ -184,23 +184,12 @@ spec:
         - op: add
           path: /spec/values/txtOwnerId
           value: "room101a7prod1"
-        - op: add
-          path: /spec/values/sources
-          value:
-            - crd
-            - ingress
-        - op: add
-          path: /spec/values/crd
-          value:
-            create: true
-            apiversion: "externaldns.k8s.io/v1alpha1" # CHECKME
-            kind: "DNSEndpoint"
         - op: replace
           path: /spec/chart/spec/version
-          # renovate: datasource=docker
+          # renovate: datasource=helm
           # chartname=external-dns
-          # url=oci://registry-1.docker.io/bitnamicharts
-          value: 8.9.2
+          # url=https://kubernetes-sigs.github.io/external-dns/
+          value: 1.18.0
       target:
         kind: HelmRelease
         name: external-dns

--- a/flux/workloads/addons/base/external-dns/external-dns-helmrelease.yaml
+++ b/flux/workloads/addons/base/external-dns/external-dns-helmrelease.yaml
@@ -10,14 +10,26 @@ spec:
       chart: external-dns
       sourceRef:
         kind: HelmRepository
-        name: bitnami
+        name: external-dns
   interval: 60m
   storageNamespace: external-dns
   targetNamespace: external-dns
   values:
-    annotationFilter: "external-dns.alpha.kubernetes.io/exclude notin (true)"
-    cloudflare:
-      proxied: false
-      secretName: external-dns-cf-auth
+    extraArgs:
+      annotation-filter: "external-dns.alpha.kubernetes.io/exclude notin (true)"
+      cloudflare-dns-records-per-page: 100
+      cloudflare-record-comment: "provisioned by external-dns"
+      crd-source-apiversion: "externaldns.k8s.io/v1alpha1"
+      crd-source-kind: "DNSEndpoint"
+    env:
+      - name: CF_API_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: external-dns-cf-auth
+            key: cloudflare_api_token
     policy: sync
-    provider: cloudflare
+    provider:
+      name: cloudflare
+    sources:
+      - crd
+      - ingress

--- a/flux/workloads/addons/base/external-dns/external-dns-helmrepository.yaml
+++ b/flux/workloads/addons/base/external-dns/external-dns-helmrepository.yaml
@@ -1,9 +1,8 @@
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
-  name: bitnami
+  name: external-dns
   namespace: external-dns
 spec:
-  interval: 1m0s
-  type: oci
-  url: oci://registry-1.docker.io/bitnamicharts
+  interval: 10m0s
+  url: https://kubernetes-sigs.github.io/external-dns/


### PR DESCRIPTION
closes https://github.com/a7d-corp/a7d-corp/issues/59

- **switch helm repository**
- **migrate helmrelease to new chart values**
- **update kustomizations**
